### PR TITLE
refactor: Rename HomeArticleAdapter to ArticleAdapter and add BlogAct…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,9 @@
         android:theme="@style/Theme.Flafla"
         tools:targetApi="31">
         <activity
+            android:name=".activities.BlogActivity"
+            android:exported="false" />
+        <activity
             android:name=".activities.FaqActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/example/flafla/activities/BlogActivity.java
+++ b/app/src/main/java/com/example/flafla/activities/BlogActivity.java
@@ -1,0 +1,73 @@
+package com.example.flafla.activities;
+
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.activity.EdgeToEdge;
+import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.flafla.R;
+import com.example.flafla.adapters.ArticleAdapter;
+import com.example.flafla.models.Article;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlogActivity extends BaseActivity {
+    private ArticleAdapter adapter;
+    private final List<Article> articleList = new ArrayList<>();
+    private FirebaseFirestore db;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.activity_blog);
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.activity_blog), (v, insets) -> {
+            Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);
+            return insets;
+        });
+
+        setupToolbar();
+
+        RecyclerView recyclerView = findViewById(R.id.recycler_home);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new ArticleAdapter(articleList, this);
+        recyclerView.setAdapter(adapter);
+
+        db = FirebaseFirestore.getInstance();
+
+        loadBlogArticles();
+    }
+
+    private void loadBlogArticles() {
+        db.collection("articles").get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    articleList.clear();
+                    adapter.notifyDataSetChanged();
+
+                    for (DocumentSnapshot doc : queryDocumentSnapshots) {
+                        addArticleFromSnapshot(doc);
+                    }
+                })
+                .addOnFailureListener(e -> Log.e("BlogActivity", "Failed to fetch articles", e));
+    }
+
+    private void addArticleFromSnapshot(@NonNull DocumentSnapshot doc) {
+        Article article = doc.toObject(Article.class);
+        if (article != null) {
+            articleList.add(article);
+            adapter.notifyItemInserted(articleList.size() - 1);
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/flafla/activities/HomeActivity.java
+++ b/app/src/main/java/com/example/flafla/activities/HomeActivity.java
@@ -18,7 +18,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
 import com.example.flafla.R;
-import com.example.flafla.adapters.HomeArticleAdapter;
+import com.example.flafla.adapters.ArticleAdapter;
 import com.example.flafla.models.Article;
 import com.example.flafla.models.HomePageContent;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class HomeActivity extends BaseActivity {
 
-    private HomeArticleAdapter adapter;
+    private ArticleAdapter adapter;
     private final List<Article> articleList = new ArrayList<>();
     private FirebaseFirestore db;
 
@@ -77,7 +77,7 @@ public class HomeActivity extends BaseActivity {
         // Inicializar el RecyclerView
         RecyclerView recyclerView = findViewById(R.id.recycler_home);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        adapter = new HomeArticleAdapter(articleList, this);
+        adapter = new ArticleAdapter(articleList, this);
         recyclerView.setAdapter(adapter);
 
         // Inicializar instancia de Firestore

--- a/app/src/main/java/com/example/flafla/adapters/ArticleAdapter.java
+++ b/app/src/main/java/com/example/flafla/adapters/ArticleAdapter.java
@@ -21,13 +21,13 @@ import com.google.android.flexbox.FlexboxLayout;
 import java.util.List;
 
 /**
- * <h1>Home Article Adapter</h1>
+ * <h1>Article Adapter</h1>
  * <p>
- * Adaptador para el RecyclerView que muestra una lista de artículos en la pantalla de inicio.
+ * Adaptador para el RecyclerView que muestra una lista de artículos en la pantalla.
  * <p>
  * Cada artículo se muestra con su título, una etiqueta (tag) y una imagen.
  */
-public class HomeArticleAdapter extends RecyclerView.Adapter<HomeArticleAdapter.ArticleViewHolder> {
+public class ArticleAdapter extends RecyclerView.Adapter<ArticleAdapter.ArticleViewHolder> {
     private final List<Article> articles;
     private final Context context;
 
@@ -37,7 +37,7 @@ public class HomeArticleAdapter extends RecyclerView.Adapter<HomeArticleAdapter.
      * @param articles Lista de artículos que serán mostrados en el RecyclerView.
      * @param context  Contexto de la aplicación para acceder a recursos y cargar imágenes.
      */
-    public HomeArticleAdapter(List<Article> articles, Context context) {
+    public ArticleAdapter(List<Article> articles, Context context) {
         this.articles = articles;
         this.context = context;
     }

--- a/app/src/main/res/layout/activity_blog.xml
+++ b/app/src/main/res/layout/activity_blog.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_blog"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activities.BlogActivity">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/blog"
+                android:drawablePadding="5dp"
+                style="@style/LocationIndicator"
+                app:drawableStartCompat="@drawable/bullet" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="12dp" />
+
+            <include layout="@layout/back_button" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="12dp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_home"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false" />
+        </LinearLayout>
+
+
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
…ivity

This commit renames the `HomeArticleAdapter` class to `ArticleAdapter` to make its name more generic and reusable. It also introduces a new `BlogActivity` to display a list of articles using the renamed adapter and fetch them from Firestore.

Key changes:

- Renamed `HomeArticleAdapter.java` to `ArticleAdapter.java`.
- Updated class name inside `ArticleAdapter.java`.
- Updated the description in the Javadoc of `ArticleAdapter.java`.
- Created `BlogActivity.java` to display a list of articles:
    - Sets up a RecyclerView and uses the `ArticleAdapter`.
    - Fetches articles from the "articles" collection in Firestore.
    - Updates the adapter with the fetched articles.
- Added the `BlogActivity` to `AndroidManifest.xml`.
- Created the corresponding layout file `activity_blog.xml`.
- Updated `HomeActivity.java` to use the renamed `ArticleAdapter`.